### PR TITLE
Add Laravel API skeleton with JWT auth and English schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# backoffice
+# Backoffice API
+
+This repository provides a minimal skeleton for a Laravel REST API translated to English. It includes JWT authentication and an OpenAPI specification.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   composer install
+   ```
+2. Configure the environment:
+   ```bash
+   cp .env.example .env
+   php artisan key:generate
+   php artisan jwt:secret
+   ```
+3. Run database migrations:
+   ```bash
+   php artisan migrate
+   ```
+
+## Documentation
+
+The API is documented using OpenAPI. The specification can be found in [`docs/openapi.yaml`](docs/openapi.yaml).

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class AuthController extends Controller
+{
+    public function login(Request $request)
+    {
+        $credentials = $request->only(['username', 'password']);
+
+        if (! $token = auth()->attempt($credentials)) {
+            return response()->json(['message' => 'Invalid credentials'], 401);
+        }
+
+        return response()->json(['token' => $token]);
+    }
+
+    public function me()
+    {
+        return response()->json(auth()->user());
+    }
+}

--- a/app/Http/Controllers/ClientController.php
+++ b/app/Http/Controllers/ClientController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Client;
+use Illuminate\Http\Request;
+
+class ClientController extends Controller
+{
+    public function index()
+    {
+        return Client::all();
+    }
+
+    public function store(Request $request)
+    {
+        $client = Client::create($request->all());
+        return response()->json($client, 201);
+    }
+
+    public function show(Client $client)
+    {
+        return $client;
+    }
+
+    public function update(Request $request, Client $client)
+    {
+        $client->update($request->all());
+        return response()->json($client);
+    }
+
+    public function destroy(Client $client)
+    {
+        $client->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller as BaseController;
+
+class Controller extends BaseController
+{
+    use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+}

--- a/app/Http/Controllers/EquipmentController.php
+++ b/app/Http/Controllers/EquipmentController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Equipment;
+use Illuminate\Http\Request;
+
+class EquipmentController extends Controller
+{
+    public function index()
+    {
+        return Equipment::all();
+    }
+
+    public function store(Request $request)
+    {
+        $equipment = Equipment::create($request->all());
+        return response()->json($equipment, 201);
+    }
+
+    public function show(Equipment $equipment)
+    {
+        return $equipment;
+    }
+
+    public function update(Request $request, Equipment $equipment)
+    {
+        $equipment->update($request->all());
+        return response()->json($equipment);
+    }
+
+    public function destroy(Equipment $equipment)
+    {
+        $equipment->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/FaultController.php
+++ b/app/Http/Controllers/FaultController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Fault;
+use Illuminate\Http\Request;
+
+class FaultController extends Controller
+{
+    public function index()
+    {
+        return Fault::all();
+    }
+
+    public function store(Request $request)
+    {
+        $fault = Fault::create($request->all());
+        return response()->json($fault, 201);
+    }
+
+    public function show(Fault $fault)
+    {
+        return $fault;
+    }
+
+    public function update(Request $request, Fault $fault)
+    {
+        $fault->update($request->all());
+        return response()->json($fault);
+    }
+
+    public function destroy(Fault $fault)
+    {
+        $fault->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/StatusController.php
+++ b/app/Http/Controllers/StatusController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Status;
+use Illuminate\Http\Request;
+
+class StatusController extends Controller
+{
+    public function index()
+    {
+        return Status::all();
+    }
+
+    public function store(Request $request)
+    {
+        $status = Status::create($request->all());
+        return response()->json($status, 201);
+    }
+
+    public function show(Status $status)
+    {
+        return $status;
+    }
+
+    public function update(Request $request, Status $status)
+    {
+        $status->update($request->all());
+        return response()->json($status);
+    }
+
+    public function destroy(Status $status)
+    {
+        $status->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/StockController.php
+++ b/app/Http/Controllers/StockController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Stock;
+use Illuminate\Http\Request;
+
+class StockController extends Controller
+{
+    public function index()
+    {
+        return Stock::all();
+    }
+
+    public function store(Request $request)
+    {
+        $stock = Stock::create($request->all());
+        return response()->json($stock, 201);
+    }
+
+    public function show(Stock $stock)
+    {
+        return $stock;
+    }
+
+    public function update(Request $request, Stock $stock)
+    {
+        $stock->update($request->all());
+        return response()->json($stock);
+    }
+
+    public function destroy(Stock $stock)
+    {
+        $stock->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+
+class UserController extends Controller
+{
+    public function index()
+    {
+        return User::all();
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->all();
+        $data['password'] = Hash::make($data['password']);
+        $user = User::create($data);
+        return response()->json($user, 201);
+    }
+
+    public function show(User $user)
+    {
+        return $user;
+    }
+
+    public function update(Request $request, User $user)
+    {
+        $data = $request->all();
+        if (isset($data['password'])) {
+            $data['password'] = Hash::make($data['password']);
+        }
+        $user->update($data);
+        return response()->json($user);
+    }
+
+    public function destroy(User $user)
+    {
+        $user->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Client extends Model
+{
+    protected $fillable = [
+        'name',
+        'address',
+        'phone',
+        'email',
+        'user_id'
+    ];
+
+    public function equipment(): HasMany
+    {
+        return $this->hasMany(Equipment::class);
+    }
+}

--- a/app/Models/Equipment.php
+++ b/app/Models/Equipment.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Equipment extends Model
+{
+    protected $fillable = [
+        'imei',
+        'model',
+        'observations',
+        'client_id'
+    ];
+
+    public function client(): BelongsTo
+    {
+        return $this->belongsTo(Client::class);
+    }
+
+    public function faults(): HasMany
+    {
+        return $this->hasMany(Fault::class);
+    }
+}

--- a/app/Models/Fault.php
+++ b/app/Models/Fault.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Fault extends Model
+{
+    protected $fillable = [
+        'equipment_id',
+        'status_id',
+        'user_id',
+        'entry_date',
+        'delivery_date',
+        'budget',
+        'client_id',
+        'observations',
+        'expected_date'
+    ];
+
+    public function equipment(): BelongsTo
+    {
+        return $this->belongsTo(Equipment::class);
+    }
+
+    public function status(): BelongsTo
+    {
+        return $this->belongsTo(Status::class);
+    }
+
+    public function client(): BelongsTo
+    {
+        return $this->belongsTo(Client::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Status.php
+++ b/app/Models/Status.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Status extends Model
+{
+    protected $fillable = [
+        'description',
+        'css_class'
+    ];
+
+    public function faults(): HasMany
+    {
+        return $this->hasMany(Fault::class);
+    }
+}

--- a/app/Models/Stock.php
+++ b/app/Models/Stock.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Stock extends Model
+{
+    protected $fillable = [
+        'equipment',
+        'cases',
+        'white_frames',
+        'black_frames',
+        'white_glasses',
+        'black_glasses',
+        'polarized_films',
+        'tempered_films'
+    ];
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+use Tymon\JWTAuth\Contracts\JWTSubject;
+
+class User extends Authenticatable implements JWTSubject
+{
+    use Notifiable;
+
+    protected $fillable = [
+        'name',
+        'username',
+        'password',
+        'type'
+    ];
+
+    protected $hidden = [
+        'password'
+    ];
+
+    public function getJWTIdentifier()
+    {
+        return $this->getKey();
+    }
+
+    public function getJWTCustomClaims(): array
+    {
+        return [];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "backoffice/api",
+    "description": "Laravel REST API with JWT authentication",
+    "type": "project",
+    "require": {
+        "php": "^8.0",
+        "laravel/framework": "^10.0",
+        "tymon/jwt-auth": "^2.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    }
+}

--- a/database/migrations/2025_08_15_000001_create_clients_table.php
+++ b/database/migrations/2025_08_15_000001_create_clients_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('clients', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 512);
+            $table->string('address', 512)->nullable();
+            $table->integer('phone');
+            $table->string('email', 512)->nullable();
+            $table->foreignId('user_id')->constrained('users');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('clients');
+    }
+};

--- a/database/migrations/2025_08_15_000002_create_equipment_table.php
+++ b/database/migrations/2025_08_15_000002_create_equipment_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('equipment', function (Blueprint $table) {
+            $table->id();
+            $table->string('imei', 512)->unique();
+            $table->string('model', 254);
+            $table->string('observations', 512);
+            $table->foreignId('client_id')->constrained('clients');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('equipment');
+    }
+};

--- a/database/migrations/2025_08_15_000003_create_statuses_table.php
+++ b/database/migrations/2025_08_15_000003_create_statuses_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('statuses', function (Blueprint $table) {
+            $table->id();
+            $table->string('description', 512);
+            $table->string('css_class', 24);
+            $table->timestamps();
+        });
+
+        DB::table('statuses')->insert([
+            ['id' => 1, 'description' => 'Under Analysis', 'css_class' => 'alert-info'],
+            ['id' => 2, 'description' => 'Under Repair', 'css_class' => 'alert-warning'],
+            ['id' => 3, 'description' => 'Not Repairable', 'css_class' => 'alert-danger'],
+            ['id' => 4, 'description' => 'Repaired', 'css_class' => 'alert-success'],
+            ['id' => 5, 'description' => 'Delivered', 'css_class' => 'alert-success'],
+            ['id' => 6, 'description' => 'Delivered without Repair', 'css_class' => 'alert-danger'],
+        ]);
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('statuses');
+    }
+};

--- a/database/migrations/2025_08_15_000004_create_stock_table.php
+++ b/database/migrations/2025_08_15_000004_create_stock_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('stock', function (Blueprint $table) {
+            $table->id();
+            $table->string('equipment', 30);
+            $table->integer('cases');
+            $table->integer('white_frames')->nullable();
+            $table->integer('black_frames')->nullable();
+            $table->integer('white_glasses')->nullable();
+            $table->integer('black_glasses')->nullable();
+            $table->integer('polarized_films')->nullable();
+            $table->integer('tempered_films')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('stock');
+    }
+};

--- a/database/migrations/2025_08_15_000005_create_users_table.php
+++ b/database/migrations/2025_08_15_000005_create_users_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 512);
+            $table->string('username', 254);
+            $table->string('password', 254);
+            $table->integer('type');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('users');
+    }
+};

--- a/database/migrations/2025_08_15_000006_create_faults_table.php
+++ b/database/migrations/2025_08_15_000006_create_faults_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('faults', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('equipment_id')->constrained('equipment');
+            $table->foreignId('status_id')->constrained('statuses');
+            $table->foreignId('user_id')->constrained('users');
+            $table->date('entry_date');
+            $table->date('delivery_date');
+            $table->double('budget')->nullable();
+            $table->foreignId('client_id')->nullable()->constrained('clients');
+            $table->string('observations', 2048);
+            $table->date('expected_date')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('faults');
+    }
+};

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.3
+info:
+  title: Backoffice API
+  version: 1.0.0
+paths:
+  /api/login:
+    post:
+      summary: Obtain JWT token
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '200':
+          description: JWT token
+  /api/clients:
+    get:
+      summary: List clients
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Client list
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/docs/schema_en.sql
+++ b/docs/schema_en.sql
@@ -1,0 +1,74 @@
+-- English translation of the original SQL schema
+
+CREATE TABLE faults (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  equipment_id INT NOT NULL,
+  status_id INT NOT NULL,
+  user_id INT NOT NULL,
+  entry_date DATE NOT NULL,
+  delivery_date DATE NOT NULL,
+  budget DOUBLE NULL,
+  client_id INT NULL,
+  observations VARCHAR(2048) NOT NULL,
+  expected_date DATE NULL,
+  CONSTRAINT fk_faults_equipment FOREIGN KEY (equipment_id) REFERENCES equipment(id),
+  CONSTRAINT fk_faults_status FOREIGN KEY (status_id) REFERENCES statuses(id),
+  CONSTRAINT fk_faults_user FOREIGN KEY (user_id) REFERENCES users(id),
+  CONSTRAINT fk_faults_client FOREIGN KEY (client_id) REFERENCES clients(id)
+);
+
+CREATE TABLE clients (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(512) NOT NULL,
+  address VARCHAR(512) NULL,
+  phone INT NOT NULL,
+  email VARCHAR(512) NULL,
+  user_id INT NOT NULL
+);
+
+CREATE TABLE equipment (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  imei VARCHAR(512) NOT NULL UNIQUE,
+  model VARCHAR(254) NOT NULL,
+  observations VARCHAR(512) NOT NULL,
+  client_id INT NOT NULL,
+  CONSTRAINT fk_equipment_client FOREIGN KEY (client_id) REFERENCES clients(id)
+);
+
+CREATE TABLE statuses (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  description VARCHAR(512) NOT NULL,
+  css_class VARCHAR(24) NOT NULL
+);
+
+INSERT INTO statuses (id, description, css_class) VALUES
+(1, 'Under Analysis', 'alert-info'),
+(2, 'Under Repair', 'alert-warning'),
+(3, 'Not Repairable', 'alert-danger'),
+(4, 'Repaired', 'alert-success'),
+(5, 'Delivered', 'alert-success'),
+(6, 'Delivered without Repair', 'alert-danger');
+
+CREATE TABLE stock (
+  id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  equipment VARCHAR(30) NOT NULL,
+  cases INT NOT NULL,
+  white_frames INT NULL,
+  black_frames INT NULL,
+  white_glasses INT NULL,
+  black_glasses INT NULL,
+  polarized_films INT NULL,
+  tempered_films INT NULL
+);
+
+INSERT INTO stock (id, equipment, cases, white_frames, black_frames, white_glasses, black_glasses, polarized_films, tempered_films) VALUES
+(6, 'Apppp', 56, 78, 67, 67, 76, 100, 65),
+(7, 'Apure', 55, 66, 77, 99, 98, 77, 66);
+
+CREATE TABLE users (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(512) NOT NULL,
+  username VARCHAR(254) NOT NULL,
+  password VARCHAR(254) NOT NULL,
+  type INT NOT NULL
+);

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AuthController;
+use App\Http\Controllers\ClientController;
+use App\Http\Controllers\EquipmentController;
+use App\Http\Controllers\FaultController;
+use App\Http\Controllers\StatusController;
+use App\Http\Controllers\StockController;
+use App\Http\Controllers\UserController;
+
+Route::post('login', [AuthController::class, 'login']);
+
+Route::middleware('auth:api')->group(function () {
+    Route::apiResource('clients', ClientController::class);
+    Route::apiResource('equipment', EquipmentController::class);
+    Route::apiResource('faults', FaultController::class);
+    Route::apiResource('statuses', StatusController::class);
+    Route::apiResource('stocks', StockController::class);
+    Route::apiResource('users', UserController::class);
+    Route::post('me', [AuthController::class, 'me']);
+});


### PR DESCRIPTION
## Summary
- scaffold Laravel-style REST API with JWT authentication
- translate Portuguese database schema and add migrations, models, controllers
- include OpenAPI documentation and setup instructions

## Testing
- `find app routes database -name '*.php' -print -exec php -l {} \;`


------
https://chatgpt.com/codex/tasks/task_e_689f041914b0832da0ee315fbeb9f99b