### PR TITLE
Add development container and CI setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "Backoffice",
+  "dockerComposeFile": ["../docker-compose.yml"],
+  "service": "app",
+  "workspaceFolder": "/var/www",
+  "postCreateCommand": "composer install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-azuretools.vscode-docker",
+        "xdebug.php-pack"
+      ]
+    }
+  }
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+vendor
+node_modules
+.env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: laravel
+          MYSQL_USER: laravel
+          MYSQL_PASSWORD: secret
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping --silent"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+    steps:
+      - uses: actions/checkout@v3
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+      - run: composer install --prefer-dist --no-progress
+      - run: php artisan key:generate
+      - run: php artisan jwt:secret --force
+      - run: php artisan migrate
+      - run: php artisan test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+FROM php:8.2-cli
+
+# Install system dependencies and PHP extensions
+RUN apt-get update && apt-get install -y \
+    git \
+    unzip \
+    libzip-dev \
+    && docker-php-ext-install pdo_mysql \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+# Set working directory
+WORKDIR /var/www
+
+# Copy application code
+COPY . /var/www
+
+# Expose application port
+EXPOSE 8000
+
+# Run Laravel development server
+CMD ["bash", "-c", "composer install && php artisan serve --host=0.0.0.0 --port=8000"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: up down build test install
+
+up:
+	 docker compose up -d
+
+down:
+	 docker compose down
+
+build:
+	 docker compose build
+
+test:
+	 docker compose run --rm app php artisan test
+
+install:
+	 docker compose run --rm app composer install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3.8"
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    environment:
+      DB_HOST: db
+      DB_PORT: 3306
+      DB_DATABASE: laravel
+      DB_USERNAME: laravel
+      DB_PASSWORD: secret
+    volumes:
+      - .:/var/www
+    depends_on:
+      - db
+
+  db:
+    image: mysql:8.0
+    command: --default-authentication-plugin=mysql_native_password
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: laravel
+      MYSQL_USER: laravel
+      MYSQL_PASSWORD: secret
+    ports:
+      - "3306:3306"
+    volumes:
+      - db-data:/var/lib/mysql
+
+volumes:
+  db-data:


### PR DESCRIPTION
## Summary
- add VS Code devcontainer configuration
- introduce Dockerfile, docker-compose with MySQL, and Makefile helpers
- configure GitHub Actions workflow for PHP tests

## Testing
- `composer validate --no-check-lock`
- `docker compose config` *(fails: command not found)*
- `php -v`
- `composer --version`
- `make test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f096bd0c4832db8837cae2517c247