### PR TITLE
Restore artisan script and bootstrap directory

### DIFF
--- a/artisan
+++ b/artisan
@@ -1,0 +1,21 @@
+#!/usr/bin/env php
+<?php
+
+use Illuminate\Contracts\Console\Kernel;
+
+define('LARAVEL_START', microtime(true));
+
+require __DIR__.'/vendor/autoload.php';
+
+$app = require_once __DIR__.'/bootstrap/app.php';
+
+$kernel = $app->make(Kernel::class);
+
+$status = $kernel->handle(
+    $input = new Symfony\Component\Console\Input\ArgvInput,
+    new Symfony\Component\Console\Output\ConsoleOutput
+);
+
+$kernel->terminate($input, $status);
+
+exit($status);

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,0 +1,24 @@
+<?php
+
+require_once __DIR__.'/../vendor/autoload.php';
+
+$app = new Illuminate\Foundation\Application(
+    $_ENV['APP_BASE_PATH'] ?? dirname(__DIR__)
+);
+
+$app->singleton(
+    Illuminate\Contracts\Http\Kernel::class,
+    App\Http\Kernel::class
+);
+
+$app->singleton(
+    Illuminate\Contracts\Console\Kernel::class,
+    App\Console\Kernel::class
+);
+
+$app->singleton(
+    Illuminate\Contracts\Debug\ExceptionHandler::class,
+    App\Exceptions\Handler::class
+);
+
+return $app;

--- a/bootstrap/cache/.gitignore
+++ b/bootstrap/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- add Laravel artisan entrypoint and bootstrap directory

## Testing
- `php artisan key:generate` *(fails: require vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_689fac2e0790832db006dcf2abcf88f2